### PR TITLE
Update AntiMicMonitoringDesync.py

### DIFF
--- a/AntiMicMonitoringDesync.py
+++ b/AntiMicMonitoringDesync.py
@@ -15,8 +15,8 @@ default_update_interval = 60
 def reset_monitoring():
   global source_name
   source = obs.obs_get_source_by_name(source_name)
-  monitoring_type = obs.obs_source_get_monitoring_type(source)
   if source:
+    monitoring_type = obs.obs_source_get_monitoring_type(source)
     obs.obs_source_set_monitoring_type(source, obs.OBS_MONITORING_TYPE_NONE)
     print("Monitoring disabled")
     obs.obs_source_set_monitoring_type(source, monitoring_type)

--- a/AntiMicMonitoringDesync.py
+++ b/AntiMicMonitoringDesync.py
@@ -15,10 +15,11 @@ default_update_interval = 60
 def reset_monitoring():
   global source_name
   source = obs.obs_get_source_by_name(source_name)
+  monitoring_type = obs.obs_source_get_monitoring_type(source)
   if source:
     obs.obs_source_set_monitoring_type(source, obs.OBS_MONITORING_TYPE_NONE)
     print("Monitoring disabled")
-    obs.obs_source_set_monitoring_type(source, obs.OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT)
+    obs.obs_source_set_monitoring_type(source, monitoring_type)
     print("Monitoring enabled")
   else:
     print(f"Monitoring device not found with the name {source_name}.")


### PR DESCRIPTION
Prior to disabling and re-enabling the monitoring source save the monitoring type so that it can be enabled using the users monitoring type that was previously set. Otherwise, it's forcing the monitoring type to be "Monitor" and "Output" and that may not always be how a user has the source configured.