### PR TITLE
Reset monitoring function rework

### DIFF
--- a/AntiMicMonitoringDesync.py
+++ b/AntiMicMonitoringDesync.py
@@ -18,12 +18,8 @@ def reset_monitoring():
   global source_name
   source = obs.obs_get_source_by_name(source_name)
   if source:
-    monitoring_type = obs.obs_source_get_monitoring_type(source)
-    obs.obs_source_set_monitoring_type(
-        source, obs.OBS_MONITORING_TYPE_NONE)
-    print("Monitoring disabled")
-    obs.obs_source_set_monitoring_type(source, monitoring_type)
-    print("Monitoring enabled")
+    obs.obs_reset_audio_monitoring()
+    print("Resetting audio monitoring")
   else:
     print(f"Monitoring device not found with the name {source_name}.")
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This OBS Script is a workaround on issues of audio monitoring desync that can ha
 If your OBS audio monitoring gets delayed over time, this script might mitigate the issue.
 
 
+## Requirements
+
+* OBS Version 30.1 or higher
+
+
 ## Installation
 
 You can either download the `AntiMicMonitoringDesync.py` file directly from github, or clone this project using the command `git clone https://github.com/MechanicallyDev/OBS-Anti-Mic-Monitoring-Desync.git`.
@@ -28,11 +33,16 @@ Contributions are always welcome!
 If you have any sugestion or issue, please leave an [issue](https://github.com/MechanicallyDev/OBS-Anti-Mic-Monitoring-Desync/issues).
 
 
+## Known issues
+
+In some cases the script may cause OBS crash on closing the app which shouldn't impact overall performance or stability.
+
+
 ## FAQ
 
 #### What does this script do?
 
-This script disables and immediately re-enables a choosen audio input device in a set interval (default: every minute).
+This script resets audio monitoring for a choosen audio input device in a set interval (default: every minute).
 
 This makes the buffer buildup disapear, forcing OBS to generate a more reasonable buffer, decreasing latency.
 
@@ -57,3 +67,8 @@ It is possible in some instances to notice the monitoring disabling and re-enabl
 #### Will my viewers be able to notice the effect of this script?
 
 No, this script only works on the monitoring side of OBS, the audio continues to be sent to your viewers even while your monitoring is off, so it doesn't affect the audio currenly being recorded or streamed.
+
+
+## Links
+
+* [OBS API Reference](https://docs.obsproject.com/reference-core)


### PR DESCRIPTION
First of all, thanks for the script, it's been helping me a lot for years.

This is a little simplification/optimization of the script for modern OBS versions.

While skimming through [OBS API Docs](https://docs.obsproject.com/reference-core) I noticed a new call - `obs_reset_audio_monitoring`. I haven't found a detailed explanation of the call but decided to try it out and it works exactly as you would expect. Resetting monitoring buffers. Worked both on Windows and Linux.

Please consider giving it a shot.

**UPD** If further tests show positive result we could probably optimize it a bit better by removing everything about generating and selecting an input device. I might try it later.